### PR TITLE
Add deregistercriticalserviceafter param to Register Options

### DIFF
--- a/lib/consul-service.options.ts
+++ b/lib/consul-service.options.ts
@@ -28,6 +28,7 @@ export interface RegisterOptions {
         health_check?: {
             timeout?: string;
             interval?: string;
+            deregistercriticalserviceafter?: string,
         };
         max_retry?: number;
         retry_interval?: number;


### PR DESCRIPTION
consul.agent.check.register(options, callback) has deregistercriticalserviceafter, its auto remove service from consul after desired timeout